### PR TITLE
Remove tax query before fetching nav menu items

### DIFF
--- a/navception.php
+++ b/navception.php
@@ -126,6 +126,8 @@ class Navception {
 			} else {
 				$args['navception_previous_menu_item_parent'] = $previous_menu_item_parent;
 			}
+			
+			unset( $args['tax_query'] );
 
 			$navception_items = wp_get_nav_menu_items( $item->object_id, $args );
 


### PR DESCRIPTION
WordPress 6.0 refactors the query in `wp_get_nav_menu_items()` to [use a tax_query](https://github.com/WordPress/wordpress-develop/pull/2399/files#diff-1b01be7c995419a8307dd2b2c8e1b4fc96e75ef07df4e8e66c45cc8273d02e0fR708). The `navception()` filter however passes along the original $args, including the newly added tax query, when fetching menu items, causing an infinite loop. This update removes the `$args['tax_query']` key before passing it along to `wp_get_nav_menu_items()`.